### PR TITLE
Extract createMainWindow and fix activate handler

### DIFF
--- a/src/main/menu/tray.ts
+++ b/src/main/menu/tray.ts
@@ -50,10 +50,8 @@ async function buildContextMenu(): Promise<Menu> {
     {
       label: 'Show Window',
       click: async () => {
-        const { mainWindow } = await import('@/main/main');
-        if (!mainWindow || mainWindow.isDestroyed()) return;
-        mainWindow.show();
-        mainWindow.focus();
+        const { createMainWindow } = await import('@/main/main');
+        await createMainWindow();
       },
     },
     { type: 'separator' },


### PR DESCRIPTION
- Extract window creation logic into a reusable `createMainWindow` exported function
- Update tray's "Show Window" to call `createMainWindow` directly instead of manually checking and showing
- Fix `activate` event to reopen the main window when the app is already running

Fixes #2