### PR TITLE
Fix widget preview scaling in main window tabs

### DIFF
--- a/src/main/utils/window.ts
+++ b/src/main/utils/window.ts
@@ -65,8 +65,6 @@ export class Window {
       show: mergedConfig.show,
       frame: mergedConfig.frame,
       transparent: mergedConfig.transparent,
-      vibrancy: mergedConfig.vibrancy,
-      visualEffectState: mergedConfig.visualEffectState,
       titleBarStyle: mergedConfig.titleBarStyle,
       titleBarOverlay: mergedConfig.titleBarOverlay,
       trafficLightPosition: mergedConfig.trafficLightPosition,

--- a/src/renderer/windows/main/active-widgets.tsx
+++ b/src/renderer/windows/main/active-widgets.tsx
@@ -20,7 +20,11 @@ function ActiveInstanceCard({
     <div className="group relative overflow-hidden rounded-xl border">
       <div className="bg-background aspect-video w-full transition-all duration-200 group-hover:scale-[1.02] group-hover:blur-[2px]">
         {widget ? (
-          <WidgetPreview code={widget.sourceCode} className="h-full w-full" />
+          <WidgetPreview
+            code={widget.sourceCode}
+            className="h-full w-full"
+            scale={0.5}
+          />
         ) : (
           <div className="flex h-full items-center justify-center">
             <span className="text-muted-foreground text-xs">

--- a/src/renderer/windows/main/widget-grid.tsx
+++ b/src/renderer/windows/main/widget-grid.tsx
@@ -35,7 +35,11 @@ function WidgetCard({
   return (
     <div className="group relative overflow-hidden rounded-xl border">
       <div className="bg-background aspect-video w-full transition-all duration-200 group-hover:scale-[1.02] group-hover:blur-[2px]">
-        <WidgetPreview code={widget.sourceCode} className="h-full w-full" />
+        <WidgetPreview
+          code={widget.sourceCode}
+          className="h-full w-full"
+          scale={0.5}
+        />
       </div>
 
       <div className="pointer-events-none absolute inset-0 bg-black/0 transition-all duration-200 group-hover:bg-black/40" />

--- a/src/types/window.ts
+++ b/src/types/window.ts
@@ -2,22 +2,6 @@ import type { BrowserWindowConstructorOptions } from 'electron';
 
 export type WindowType = 'main' | 'widget';
 
-export type VibrancyMaterial =
-  | 'titlebar'
-  | 'selection'
-  | 'menu'
-  | 'popover'
-  | 'sidebar'
-  | 'header'
-  | 'sheet'
-  | 'window'
-  | 'hud'
-  | 'fullscreen-ui'
-  | 'tooltip'
-  | 'content'
-  | 'under-window'
-  | 'under-page';
-
 export type TitleBarStyle =
   | 'default'
   | 'hidden'
@@ -49,8 +33,6 @@ export interface WindowConfig {
   show?: boolean;
   frame?: boolean;
   transparent?: boolean;
-  vibrancy?: VibrancyMaterial;
-  visualEffectState?: 'followWindow' | 'active' | 'inactive';
   titleBarStyle?: TitleBarStyle;
   titleBarOverlay?:
     | boolean


### PR DESCRIPTION
- Apply `scale={0.5}` to `WidgetPreview` in both the Available Widgets and Active Widgets tabs, matching the existing behavior in the template picker
- Remove unused `vibrancy` and `visualEffectState` properties from `WindowConfig` and related types