### PR TITLE
Implement full auto-update flow with tray and toast

### DIFF
--- a/src/main/system/index.ts
+++ b/src/main/system/index.ts
@@ -17,4 +17,12 @@ export {
   updateSetting,
 } from '@/main/system/settings';
 
-export { initAutoUpdater, registerUpdaterIpc } from '@/main/system/updater';
+export {
+  checkForUpdates,
+  getUpdateStatus,
+  initAutoUpdater,
+  installUpdate,
+  registerUpdaterIpc,
+  setOnStatusChange,
+} from '@/main/system/updater';
+export type { UpdateState } from '@/main/system/updater';

--- a/src/renderer/components/shared/update-toast.tsx
+++ b/src/renderer/components/shared/update-toast.tsx
@@ -1,37 +1,56 @@
 import { useCallback, useEffect, useState } from 'react';
-import { Download, RefreshCw, X } from 'lucide-react';
+import { AlertCircle, CheckCircle, Download, Loader2, X } from 'lucide-react';
 
-type UpdateStatus = 'idle' | 'downloading' | 'ready';
+import { Progress } from '@/renderer/components/ui/progress';
+
+type UpdateState =
+  | 'idle'
+  | 'checking'
+  | 'available'
+  | 'downloading'
+  | 'ready'
+  | 'error';
+
+interface UpdateStatus {
+  state: UpdateState;
+  version?: string;
+  progress?: number;
+  error?: string;
+}
 
 export default function UpdateToast() {
-  const [status, setStatus] = useState<UpdateStatus>('idle');
-  const [version, setVersion] = useState('');
+  const [status, setStatus] = useState<UpdateStatus>({ state: 'idle' });
   const [dismissed, setDismissed] = useState(false);
 
   useEffect(() => {
     if (!window.ipcRenderer) return;
 
-    const handleAvailable = (_: unknown, v: unknown) => {
-      setStatus('downloading');
-      setVersion(v as string);
+    window.ipcRenderer
+      .invoke('updater:get-status')
+      .then((s: unknown) => setStatus(s as UpdateStatus));
+
+    const handleStatus = (_: unknown, newStatus: unknown) => {
+      const s = newStatus as UpdateStatus;
+      setStatus(s);
+      if (s.state === 'ready') {
+        setDismissed(false);
+      }
     };
 
-    const handleDownloaded = (_: unknown, v: unknown) => {
-      setStatus('ready');
-      setVersion(v as string);
-      setDismissed(false);
+    const handleStartInstall = () => {
+      window.ipcRenderer.invoke('updater:install');
     };
 
-    window.ipcRenderer.on('updater:available', handleAvailable);
-    window.ipcRenderer.on('updater:downloaded', handleDownloaded);
+    window.ipcRenderer.on('updater:status', handleStatus);
+    window.ipcRenderer.on('updater:start-install', handleStartInstall);
 
     return () => {
-      window.ipcRenderer.off('updater:available', handleAvailable);
-      window.ipcRenderer.off('updater:downloaded', handleDownloaded);
+      window.ipcRenderer.off('updater:status', handleStatus);
+      window.ipcRenderer.off('updater:start-install', handleStartInstall);
     };
   }, []);
 
-  const handleRestart = useCallback(() => {
+  const handleInstall = useCallback(() => {
     window.ipcRenderer.invoke('updater:install');
   }, []);
 
@@ -39,33 +58,69 @@ export default function UpdateToast() {
     setDismissed(true);
   }, []);
 
-  if (status === 'idle' || dismissed) return null;
+  if (status.state === 'idle' || status.state === 'checking' || dismissed) {
+    return null;
+  }
 
   return (
-    <div className="border-border bg-popover text-popover-foreground fixed right-4 bottom-4 z-50 flex items-center gap-3 rounded-lg border px-4 py-3 text-sm shadow-lg">
-      {status === 'downloading' && (
-        <>
-          <Download className="h-4 w-4 shrink-0 animate-pulse" />
-          <span>Downloading update v{version}...</span>
-        </>
-      )}
-      {status === 'ready' && (
-        <>
-          <RefreshCw className="h-4 w-4 shrink-0" />
-          <span>v{version} ready.</span>
-          <button
-            onClick={handleRestart}
-            className="bg-primary text-primary-foreground hover:bg-primary/90 rounded-md px-3 py-1 text-xs font-medium transition-colors"
-          >
-            Restart
-          </button>
+    <div className="border-border bg-popover text-popover-foreground fixed right-4 bottom-4 z-50 flex min-w-72 flex-col gap-2 rounded-lg border p-4 text-sm shadow-lg">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          {status.state === 'available' && (
+            <>
+              <Download className="text-primary h-4 w-4 shrink-0" />
+              <span>Update v{status.version} available</span>
+            </>
+          )}
+          {status.state === 'downloading' && (
+            <>
+              <Loader2 className="text-primary h-4 w-4 shrink-0 animate-spin" />
+              <span>Downloading v{status.version}...</span>
+            </>
+          )}
+          {status.state === 'ready' && (
+            <>
+              <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+              <span>v{status.version} ready to install</span>
+            </>
+          )}
+          {status.state === 'error' && (
+            <>
+              <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+              <span>Update failed</span>
+            </>
+          )}
+        </div>
+        {(status.state === 'ready' || status.state === 'error') && (
           <button
             onClick={handleDismiss}
-            className="hover:bg-accent rounded-md p-1 transition-colors"
+            className="hover:bg-accent -mr-1 rounded-md p-1 transition-colors"
           >
             <X className="h-3.5 w-3.5" />
           </button>
-        </>
+        )}
+      </div>
+
+      {status.state === 'downloading' && status.progress !== undefined && (
+        <div className="flex items-center gap-2">
+          <Progress value={status.progress} className="h-1.5 flex-1" />
+          <span className="text-muted-foreground w-10 text-right text-xs">
+            {status.progress}%
+          </span>
+        </div>
+      )}
+
+      {status.state === 'ready' && (
+        <button
+          onClick={handleInstall}
+          className="bg-primary text-primary-foreground hover:bg-primary/90 mt-1 w-full rounded-md px-3 py-1.5 text-xs font-medium transition-colors"
+        >
+          Restart to Update
+        </button>
+      )}
+
+      {status.state === 'error' && status.error && (
+        <p className="text-muted-foreground text-xs">{status.error}</p>
       )}
     </div>
   );

--- a/src/renderer/components/ui/progress.tsx
+++ b/src/renderer/components/ui/progress.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/renderer/lib/utils';
+
+interface ProgressProps {
+  value?: number;
+  className?: string;
+}
+
+export function Progress({ value = 0, className }: ProgressProps) {
+  return (
+    <div
+      className={cn(
+        'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
+        className,
+      )}
+    >
+      <div
+        className="bg-primary h-full transition-all duration-300"
+        style={{ width: `${Math.min(100, Math.max(0, value))}%` }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
- Add tray menu item that dynamically reflects update state (check, checking, downloading with %, update available → opens window & installs)
- Replace stub update toast with a full state-driven toast showing progress bar, version, restart button, and error message
- Decouple updater↔tray circular dependency using a callback pattern (`setOnStatusChange`) instead of a dynamic import