### PR TITLE
Proxy widget fetch through main process to bypass CORS

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { createTray } from '@/main/menu';
 import {
   initAutoUpdater,
+  registerFetchProxyIpc,
   registerUpdaterIpc,
   startCursorProximityTracking,
 } from '@/main/system';
@@ -65,6 +66,7 @@ async function initializeApp(): Promise<void> {
   await ensureConfigDirectories();
   registerWidgetIpc();
   registerUpdaterIpc();
+  registerFetchProxyIpc();
   await createTray();
 
   await createMainWindow();

--- a/src/main/system/fetch-proxy.ts
+++ b/src/main/system/fetch-proxy.ts
@@ -1,0 +1,64 @@
+import { ipcMain, net } from 'electron';
+
+interface FetchRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+}
+
+interface FetchResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export function registerFetchProxyIpc(): void {
+  ipcMain.handle(
+    'fetch:request',
+    async (_, request: FetchRequest): Promise<FetchResponse> => {
+      if (!request?.url || typeof request.url !== 'string') {
+        return {
+          ok: false,
+          status: 400,
+          statusText: 'Bad Request',
+          headers: {},
+          body: 'Invalid or missing URL',
+        };
+      }
+
+      try {
+        const response = await net.fetch(request.url, {
+          method: request.method,
+          headers: request.headers,
+          body: request.body ?? undefined,
+        });
+
+        const headers: Record<string, string> = {};
+        response.headers.forEach((value, key) => {
+          headers[key] = value;
+        });
+
+        const body = await response.text();
+
+        return {
+          ok: response.ok,
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+          body,
+        };
+      } catch {
+        return {
+          ok: false,
+          status: 0,
+          statusText: '',
+          headers: {},
+          body: 'Network request failed',
+        };
+      }
+    },
+  );
+}

--- a/src/main/system/index.ts
+++ b/src/main/system/index.ts
@@ -5,6 +5,8 @@ export {
   removeWidgetFromTracking,
 } from '@/main/system/cursor-proximity';
 
+export { registerFetchProxyIpc } from '@/main/system/fetch-proxy';
+
 export {
   encryptSecret,
   decryptSecret,

--- a/src/renderer/components/widget/widget-preview.tsx
+++ b/src/renderer/components/widget/widget-preview.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import type { WidgetSourceFiles } from '@/types';
 import { cn } from '@/renderer/lib/utils';
@@ -16,12 +16,43 @@ const RESET_CSS =
   '*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }\n' +
   'html, body { width: 100%; height: 100%; overflow: hidden; background: transparent; }';
 
+const FETCH_OVERRIDE = `(function(){
+  var pending={};var id=0;
+  window.fetch=function(input,init){
+    var url=typeof input==='string'?input:input instanceof URL?input.toString():input instanceof Request?input.url:String(input);
+    if(url.startsWith('data:')||url.startsWith('blob:'))return Object.getPrototypeOf(window).fetch.call(window,input,init);
+    var method=(init&&init.method)||'GET';
+    var headers={};
+    if(init&&init.headers){
+      if(init.headers instanceof Headers)init.headers.forEach(function(v,k){headers[k]=v;});
+      else if(Array.isArray(init.headers))init.headers.forEach(function(p){headers[p[0]]=p[1];});
+      else headers=Object.assign({},init.headers);
+    }
+    var bodyP=init&&init.body!=null?(typeof init.body==='string'?Promise.resolve(init.body):init.body instanceof Blob?init.body.text():Promise.resolve(String(init.body))):Promise.resolve(null);
+    return bodyP.then(function(body){
+      return new Promise(function(resolve,reject){
+        var rid=++id;
+        pending[rid]={resolve:resolve,reject:reject};
+        parent.postMessage({type:'wigify-fetch',id:rid,url:url,method:method.toUpperCase(),headers:headers,body:body},'*');
+      });
+    });
+  };
+  window.addEventListener('message',function(e){
+    if(!e.data||e.data.type!=='wigify-fetch-response')return;
+    var cb=pending[e.data.id];if(!cb)return;
+    delete pending[e.data.id];
+    if(e.data.error)cb.reject(new Error(e.data.error));
+    else cb.resolve(new Response(e.data.body,{status:e.data.status,statusText:e.data.statusText,headers:e.data.headers}));
+  });
+})();`;
+
 function buildSrcdoc({ html, css, js }: WidgetSourceFiles): string {
   const doc = [
     '<!doctype html>',
     '<html>',
     '<head>',
     `<style>${RESET_CSS}\n${css}</style>`,
+    `<script>${FETCH_OVERRIDE}</` + 'script>',
     '</head>',
     `<body>${html}`,
     js ? `<script>${js}</` + 'script>' : '',
@@ -41,6 +72,48 @@ export default function WidgetPreview({
   const [loading, setLoading] = useState(true);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevSrcdocRef = useRef(srcdoc);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  const handleFetchProxy = useCallback((e: MessageEvent) => {
+    if (!e.data || e.data.type !== 'wigify-fetch') return;
+    const iframe = iframeRef.current;
+    if (!iframe?.contentWindow || e.source !== iframe.contentWindow) return;
+
+    const { id, url, method, headers, body } = e.data;
+    window.ipcRenderer
+      .invoke<{
+        ok: boolean;
+        status: number;
+        statusText: string;
+        headers: Record<string, string>;
+        body: string;
+      }>('fetch:request', { url, method, headers, body })
+      .then(res => {
+        iframe.contentWindow?.postMessage(
+          {
+            type: 'wigify-fetch-response',
+            id,
+            ok: res.ok,
+            status: res.status,
+            statusText: res.statusText,
+            headers: res.headers,
+            body: res.body,
+          },
+          '*',
+        );
+      })
+      .catch(err => {
+        iframe.contentWindow?.postMessage(
+          { type: 'wigify-fetch-response', id, error: err.message },
+          '*',
+        );
+      });
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('message', handleFetchProxy);
+    return () => window.removeEventListener('message', handleFetchProxy);
+  }, [handleFetchProxy]);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -82,6 +155,7 @@ export default function WidgetPreview({
   return (
     <div className={cn('relative overflow-hidden', className)}>
       <iframe
+        ref={iframeRef}
         srcDoc={srcdoc}
         sandbox="allow-scripts"
         className={cn('border-0', !scale && 'h-full w-full')}

--- a/widget.html
+++ b/widget.html
@@ -131,6 +131,65 @@
     </div>
     <script>
       (function () {
+        var nativeFetch = window.fetch.bind(window);
+
+        window.fetch = function (input, init) {
+          var url =
+            typeof input === 'string'
+              ? input
+              : input instanceof URL
+                ? input.toString()
+                : input instanceof Request
+                  ? input.url
+                  : String(input);
+
+          if (url.startsWith('data:') || url.startsWith('blob:')) {
+            return nativeFetch(input, init);
+          }
+
+          var method = (init && init.method) || 'GET';
+          var headers = {};
+          if (init && init.headers) {
+            if (init.headers instanceof Headers) {
+              init.headers.forEach(function (v, k) {
+                headers[k] = v;
+              });
+            } else if (Array.isArray(init.headers)) {
+              init.headers.forEach(function (pair) {
+                headers[pair[0]] = pair[1];
+              });
+            } else {
+              headers = Object.assign({}, init.headers);
+            }
+          }
+
+          var bodyPromise =
+            init && init.body != null
+              ? typeof init.body === 'string'
+                ? Promise.resolve(init.body)
+                : init.body instanceof Blob
+                  ? init.body.text()
+                  : Promise.resolve(String(init.body))
+              : Promise.resolve(null);
+
+          return bodyPromise.then(function (body) {
+            return window.ipcRenderer
+              .invoke('fetch:request', {
+                url: url,
+                method: method.toUpperCase(),
+                headers: headers,
+                body: body,
+              })
+              .then(function (res) {
+                return new Response(res.body, {
+                  status: res.status,
+                  statusText: res.statusText,
+                  headers: res.headers,
+                });
+              });
+          });
+        };
+
         var payload = null;
 
         var wigify = {
@@ -189,6 +248,7 @@
           var inlineScripts = document.body.querySelectorAll('script');
           inlineScripts.forEach(function (original) {
             var fresh = document.createElement('script');
+            if (original.type) fresh.type = original.type;
             if (original.src) {
               fresh.src = original.src;
             } else {


### PR DESCRIPTION
- Override `window.fetch` in widget windows and preview iframe to route HTTP requests through Electron's main process via IPC
- Add `fetch:request` IPC handler using `net.fetch` (no CORS restrictions) with graceful error handling for invalid URLs
- Fix `<script type="module">` tags not being preserved when widget HTML scripts are re-injected

Fixes #15