### PR TITLE
Improve 3-dot menu button visibility on widget cards

### DIFF
--- a/src/renderer/windows/main/widget-grid.tsx
+++ b/src/renderer/windows/main/widget-grid.tsx
@@ -62,7 +62,7 @@ function WidgetCard({
             <Button
               variant="secondary"
               size="icon"
-              className="pointer-events-auto h-7 w-7 rounded-lg"
+              className="pointer-events-auto h-7 w-7 rounded-lg bg-black/60 text-white hover:bg-black/80"
             >
               <MoreHorizontal className="h-3.5 w-3.5" />
             </Button>


### PR DESCRIPTION
- Apply dark semi-transparent background (`bg-black/60`) and white text to the 3-dot menu button on widget cards
- Ensures the button is clearly visible against any widget background when hovering

Fixes #3