### PR TITLE
Show toast feedback when checking for updates from tray

### DIFF
--- a/src/main/menu/tray.ts
+++ b/src/main/menu/tray.ts
@@ -38,6 +38,12 @@ async function openMainWindowAndUpdate(): Promise<void> {
   installUpdate();
 }
 
+async function openMainWindowAndCheckForUpdates(): Promise<void> {
+  const { createMainWindow } = await import('@/main/main');
+  await createMainWindow();
+  checkForUpdates();
+}
+
 function getUpdateMenuItem(): Electron.MenuItemConstructorOptions | null {
   const status = getUpdateStatus();
 
@@ -64,12 +70,12 @@ function getUpdateMenuItem(): Electron.MenuItemConstructorOptions | null {
       return {
         label: 'Check for Updates',
         sublabel: 'Last check failed',
-        click: checkForUpdates,
+        click: openMainWindowAndCheckForUpdates,
       };
     default:
       return {
         label: 'Check for Updates',
-        click: checkForUpdates,
+        click: openMainWindowAndCheckForUpdates,
       };
   }
 }

--- a/src/main/system/updater.ts
+++ b/src/main/system/updater.ts
@@ -9,6 +9,7 @@ export type UpdateState =
   | 'available'
   | 'downloading'
   | 'ready'
+  | 'up-to-date'
   | 'error';
 
 interface UpdateStatus {
@@ -44,9 +45,17 @@ export function getUpdateStatus(): UpdateStatus {
   return currentStatus;
 }
 
+function simulateUpdateCheck(): void {
+  updateStatus({ state: 'checking' });
+  setTimeout(() => {
+    updateStatus({ state: 'up-to-date' });
+    setTimeout(() => updateStatus({ state: 'idle' }), 3000);
+  }, 1500);
+}
+
 export function checkForUpdates(): void {
   if (isDev) {
-    updateStatus({ state: 'idle' });
+    simulateUpdateCheck();
     return;
   }
   updateStatus({ state: 'checking' });
@@ -84,7 +93,8 @@ export function initAutoUpdater(): void {
   });
 
   autoUpdater.on('update-not-available', () => {
-    updateStatus({ state: 'idle' });
+    updateStatus({ state: 'up-to-date' });
+    setTimeout(() => updateStatus({ state: 'idle' }), 3000);
   });
 
   autoUpdater.on('error', error => {

--- a/src/renderer/components/shared/update-toast.tsx
+++ b/src/renderer/components/shared/update-toast.tsx
@@ -1,5 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { AlertCircle, CheckCircle, Download, Loader2, X } from 'lucide-react';
+import {
+  AlertCircle,
+  CheckCircle,
+  CircleCheck,
+  Download,
+  Loader2,
+  X,
+} from 'lucide-react';
 
 import { Progress } from '@/renderer/components/ui/progress';
 
@@ -9,6 +16,7 @@ type UpdateState =
   | 'available'
   | 'downloading'
   | 'ready'
+  | 'up-to-date'
   | 'error';
 
 interface UpdateStatus {
@@ -58,7 +66,7 @@ export default function UpdateToast() {
     setDismissed(true);
   }, []);
 
-  if (status.state === 'idle' || status.state === 'checking' || dismissed) {
+  if (status.state === 'idle' || dismissed) {
     return null;
   }
 
@@ -66,6 +74,18 @@ export default function UpdateToast() {
     <div className="border-border bg-popover text-popover-foreground fixed right-4 bottom-4 z-50 flex min-w-72 flex-col gap-2 rounded-lg border p-4 text-sm shadow-lg">
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
+          {status.state === 'checking' && (
+            <>
+              <Loader2 className="text-primary h-4 w-4 shrink-0 animate-spin" />
+              <span>Checking for updates...</span>
+            </>
+          )}
+          {status.state === 'up-to-date' && (
+            <>
+              <CircleCheck className="h-4 w-4 shrink-0 text-green-500" />
+              <span>You're up to date</span>
+            </>
+          )}
           {status.state === 'available' && (
             <>
               <Download className="text-primary h-4 w-4 shrink-0" />


### PR DESCRIPTION
- Open main window automatically before triggering an update check from the tray
- Show a spinner toast while checking and a success toast when already up to date (auto-dismisses after 3s)
- Add dev-mode simulation that cycles through checking → up-to-date states for testing