### PR TITLE
Add tooltips, widget reload-all, and open widgets folder

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "wigify",
       "dependencies": {
+        "@radix-ui/react-tooltip": "^1.2.8",
         "electron-updater": "^6.8.3",
       },
       "devDependencies": {
@@ -239,6 +240,8 @@
 
     "@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA=="],
 
+    "@radix-ui/react-tooltip": ["@radix-ui/react-tooltip@1.2.8", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg=="],
+
     "@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 
     "@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.2", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg=="],
@@ -252,6 +255,8 @@
     "@radix-ui/react-use-rect": ["@radix-ui/react-use-rect@1.1.1", "", { "dependencies": { "@radix-ui/rect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w=="],
 
     "@radix-ui/react-use-size": ["@radix-ui/react-use-size@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ=="],
+
+    "@radix-ui/react-visually-hidden": ["@radix-ui/react-visually-hidden@1.2.3", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug=="],
 
     "@radix-ui/rect": ["@radix-ui/rect@1.1.1", "", {}, "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw=="],
 
@@ -1336,6 +1341,8 @@
     "@radix-ui/react-popover/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "pre-commit": "bun lint && bun run test && bun format"
   },
   "dependencies": {
+    "@radix-ui/react-tooltip": "^1.2.8",
     "electron-updater": "^6.8.3"
   },
   "devDependencies": {

--- a/src/main/widget/ipc/index.ts
+++ b/src/main/widget/ipc/index.ts
@@ -1,5 +1,6 @@
-import { ipcMain, shell } from 'electron';
+import { app, ipcMain, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
+import path from 'node:path';
 
 import type {
   WidgetBuildResult,
@@ -32,7 +33,11 @@ import {
 } from '@/main/widget/fs';
 import type { CreateWidgetOptions } from '@/main/widget/fs';
 import { arrangeAllWidgets, findNextGridPosition } from '@/main/widget/grid';
-import { closeWidgetWindow, spawnWidgetWindow } from '@/main/widget/manager';
+import {
+  closeAllWidgetWindows,
+  closeWidgetWindow,
+  spawnWidgetWindow,
+} from '@/main/widget/manager';
 
 async function notifyWidgetChanged(): Promise<void> {
   const { mainWindow } = await import('@/main/main');
@@ -238,5 +243,31 @@ export function registerWidgetIpc(): void {
   ipcMain.handle('widget:arrange', async (): Promise<void> => {
     await arrangeAllWidgets();
     await notifyWidgetChanged();
+  });
+
+  ipcMain.handle('widget:reload-all', async (): Promise<void> => {
+    closeAllWidgetWindows();
+
+    const widgets = await listAllWidgets();
+    for (const widget of widgets) {
+      await buildWidget(widget.manifest.name);
+    }
+
+    const instances = await getEnabledWidgetInstances();
+    for (const instance of instances) {
+      await spawnWidgetWindow(instance);
+    }
+
+    await notifyWidgetChanged();
+  });
+
+  ipcMain.handle('widget:open-widgets-dir', async (): Promise<void> => {
+    const widgetsDir = path.join(
+      app.getPath('home'),
+      '.config',
+      'wigify',
+      'widgets',
+    );
+    await shell.openPath(widgetsDir);
   });
 }

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { cn } from '@/renderer/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ComponentRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 overflow-hidden rounded-md px-3 py-1.5 text-xs',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/renderer/windows/main/index.tsx
+++ b/src/renderer/windows/main/index.tsx
@@ -1,8 +1,14 @@
 import { useCallback, useState } from 'react';
-import { Plus } from 'lucide-react';
+import { FolderOpen, Plus, RefreshCw } from 'lucide-react';
 import type { WidgetState } from '@/types';
 import TitleBar from '@/renderer/components/shared/title-bar';
 import { Button } from '@/renderer/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/renderer/components/ui/tooltip';
 import { useWidgets } from '@/renderer/hooks/use-widgets';
 import ActiveWidgets from '@/renderer/windows/main/active-widgets';
 import EmptyPage from '@/renderer/windows/main/empty';
@@ -31,6 +37,14 @@ export default function MainWindow() {
   const handleAddWidget = useCallback(() => {
     setEditingWidget(null);
     setRoute('editor');
+  }, []);
+
+  const handleReload = useCallback(() => {
+    window.ipcRenderer.invoke('widget:reload-all');
+  }, []);
+
+  const handleOpenWidgetsFolder = useCallback(() => {
+    window.ipcRenderer.invoke('widget:open-widgets-dir');
   }, []);
 
   const handleEditWidget = useCallback((widget: WidgetState) => {
@@ -67,14 +81,47 @@ export default function MainWindow() {
         activeTab={activeTab}
         onTabChange={id => setActiveTab(id as HomeTab)}
         trailing={
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={handleAddWidget}
-          >
-            <Plus className="text-muted-foreground h-3.5 w-3.5" />
-          </Button>
+          <TooltipProvider delayDuration={300}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={handleOpenWidgetsFolder}
+                >
+                  <FolderOpen className="text-muted-foreground h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Open widgets folder</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={handleReload}
+                >
+                  <RefreshCw className="text-muted-foreground h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Reload all widgets</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={handleAddWidget}
+                >
+                  <Plus className="text-muted-foreground h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Add widget</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         }
       />
       {activeTab === 'active' ? (

--- a/src/renderer/windows/main/widget-editor.tsx
+++ b/src/renderer/windows/main/widget-editor.tsx
@@ -11,6 +11,12 @@ import { templates } from '@/templates';
 import type { Template } from '@/templates';
 import type { WidgetSourceFiles, WidgetState } from '@/types';
 import { Button } from '@/renderer/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/renderer/components/ui/tooltip';
 import MonacoEditor from '@/renderer/components/widget/monaco-editor';
 import WidgetPreview from '@/renderer/components/widget/widget-preview';
 import TemplatePicker from '@/renderer/components/widget/template-picker';
@@ -208,55 +214,77 @@ export default function WidgetEditor({
           isMac ? 'pr-3 pl-20' : 'px-3',
         )}
       >
-        <div className="titlebar-no-drag flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={onBack}
-          >
-            <ChevronLeft className="text-muted-foreground h-3.5 w-3.5" />
-          </Button>
-          <span className="text-foreground text-sm font-medium">{title}</span>
-        </div>
+        <TooltipProvider delayDuration={300}>
+          <div className="titlebar-no-drag flex items-center gap-2">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={onBack}
+                >
+                  <ChevronLeft className="text-muted-foreground h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Back</TooltipContent>
+            </Tooltip>
+            <span className="text-foreground text-sm font-medium">{title}</span>
+          </div>
 
-        <div className="titlebar-no-drag flex items-center gap-1">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => setTemplatePickerOpen(true)}
-          >
-            <LayoutTemplate className="text-muted-foreground h-3.5 w-3.5" />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            disabled={!canSave}
-            onClick={handleSave}
-          >
-            <Save
-              className={cn(
-                'h-3.5 w-3.5',
-                canSave ? 'text-foreground' : 'text-muted-foreground',
-              )}
-            />
-          </Button>
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => setSidebarOpen(prev => !prev)}
-          >
-            <PanelRight
-              className={cn(
-                'h-3.5 w-3.5',
-                sidebarOpen ? 'text-foreground' : 'text-muted-foreground',
-              )}
-            />
-          </Button>
-        </div>
+          <div className="titlebar-no-drag flex items-center gap-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => setTemplatePickerOpen(true)}
+                >
+                  <LayoutTemplate className="text-muted-foreground h-3.5 w-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Templates</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  disabled={!canSave}
+                  onClick={handleSave}
+                >
+                  <Save
+                    className={cn(
+                      'h-3.5 w-3.5',
+                      canSave ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Save</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  onClick={() => setSidebarOpen(prev => !prev)}
+                >
+                  <PanelRight
+                    className={cn(
+                      'h-3.5 w-3.5',
+                      sidebarOpen ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                  />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Toggle sidebar</TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
       </div>
 
       <div className="window-content flex min-h-0 flex-1">

--- a/widget-templates/countdown/script.js
+++ b/widget-templates/countdown/script.js
@@ -6,10 +6,6 @@
       : now.getFullYear() + 1;
   var target = new Date(targetYear, 0, 1);
 
-  var circumference = 2 * Math.PI * 12;
-  var progressEl = document.getElementById('progress');
-  progressEl.style.strokeDasharray = circumference;
-
   function pad(n) {
     return n < 10 ? '0' + n : String(n);
   }
@@ -34,9 +30,6 @@
     document.getElementById('hours').textContent = pad(h);
     document.getElementById('mins').textContent = pad(m);
     document.getElementById('secs').textContent = pad(s);
-
-    var secProgress = 1 - s / 60;
-    progressEl.style.strokeDashoffset = circumference * secProgress;
 
     requestAnimationFrame(update);
   }

--- a/widget-templates/countdown/style.css
+++ b/widget-templates/countdown/style.css
@@ -37,17 +37,6 @@
     transform: rotate(360deg);
   }
 }
-.event-name {
-  font-size: 11px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 2px;
-  opacity: 0.4;
-  position: relative;
-  writing-mode: vertical-lr;
-  text-orientation: mixed;
-  transform: rotate(180deg);
-}
 .units {
   display: flex;
   gap: 6px;
@@ -83,24 +72,4 @@
   font-weight: 300;
   opacity: 0.15;
   margin-bottom: 12px;
-}
-.progress-ring {
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-  position: relative;
-}
-.progress-ring circle {
-  fill: none;
-  stroke-width: 2;
-}
-.progress-ring .bg {
-  stroke: rgba(255, 255, 255, 0.06);
-}
-.progress-ring .fg {
-  stroke: #8b5cf6;
-  stroke-linecap: round;
-  transform: rotate(-90deg);
-  transform-origin: 50% 50%;
-  transition: stroke-dashoffset 1s linear;
 }

--- a/widget-templates/countdown/widget.html
+++ b/widget-templates/countdown/widget.html
@@ -1,5 +1,4 @@
 <div class="container">
-  <div class="event-name" id="event-name">New Year</div>
   <div class="units">
     <div class="unit">
       <div class="unit-value" id="days">--</div>
@@ -21,8 +20,4 @@
       <div class="unit-label">Secs</div>
     </div>
   </div>
-  <svg class="progress-ring" viewBox="0 0 28 28">
-    <circle class="bg" cx="14" cy="14" r="12" />
-    <circle class="fg" id="progress" cx="14" cy="14" r="12" />
-  </svg>
 </div>

--- a/widget-templates/weather/script.js
+++ b/widget-templates/weather/script.js
@@ -1,0 +1,122 @@
+(function () {
+  var DEFAULT_LAT = 37.7749;
+  var DEFAULT_LON = -122.4194;
+  var DEFAULT_CITY = 'San Francisco';
+
+  var WMO_CONDITIONS = {
+    0: { text: 'Clear Sky', icon: 'clear' },
+    1: { text: 'Mostly Clear', icon: 'clear' },
+    2: { text: 'Partly Cloudy', icon: 'partly-cloudy' },
+    3: { text: 'Overcast', icon: 'cloudy' },
+    45: { text: 'Fog', icon: 'fog' },
+    48: { text: 'Freezing Fog', icon: 'fog' },
+    51: { text: 'Light Drizzle', icon: 'rain' },
+    53: { text: 'Drizzle', icon: 'rain' },
+    55: { text: 'Heavy Drizzle', icon: 'rain' },
+    56: { text: 'Freezing Drizzle', icon: 'rain' },
+    57: { text: 'Freezing Drizzle', icon: 'rain' },
+    61: { text: 'Light Rain', icon: 'rain' },
+    63: { text: 'Rain', icon: 'rain' },
+    65: { text: 'Heavy Rain', icon: 'rain' },
+    66: { text: 'Freezing Rain', icon: 'rain' },
+    67: { text: 'Freezing Rain', icon: 'rain' },
+    71: { text: 'Light Snow', icon: 'snow' },
+    73: { text: 'Snow', icon: 'snow' },
+    75: { text: 'Heavy Snow', icon: 'snow' },
+    77: { text: 'Snow Grains', icon: 'snow' },
+    80: { text: 'Light Showers', icon: 'rain' },
+    81: { text: 'Showers', icon: 'rain' },
+    82: { text: 'Heavy Showers', icon: 'rain' },
+    85: { text: 'Snow Showers', icon: 'snow' },
+    86: { text: 'Heavy Snow Showers', icon: 'snow' },
+    95: { text: 'Thunderstorm', icon: 'thunder' },
+    96: { text: 'Thunderstorm w/ Hail', icon: 'thunder' },
+    99: { text: 'Thunderstorm w/ Hail', icon: 'thunder' },
+  };
+
+  var tempEl = document.getElementById('temp');
+  var conditionEl = document.getElementById('condition');
+  var locationEl = document.getElementById('location');
+  var iconWrap = document.getElementById('icon-wrap');
+
+  function render(data) {
+    var code = data.weatherCode;
+    var info = WMO_CONDITIONS[code] || { text: 'Unknown', icon: 'cloudy' };
+
+    tempEl.innerHTML = Math.round(data.temperature) + '<span>&deg;C</span>';
+    conditionEl.textContent = info.text;
+    locationEl.textContent = data.city;
+    iconWrap.className = 'icon-wrap ' + info.icon;
+  }
+
+  function fetchWeather(lat, lon, city) {
+    var url =
+      'https://api.open-meteo.com/v1/forecast?latitude=' +
+      lat +
+      '&longitude=' +
+      lon +
+      '&current=temperature_2m,weather_code';
+
+    fetch(url)
+      .then(function (res) {
+        return res.json();
+      })
+      .then(function (data) {
+        render({
+          temperature: data.current.temperature_2m,
+          weatherCode: data.current.weather_code,
+          city: city,
+        });
+      })
+      .catch(function () {
+        conditionEl.textContent = 'Failed to load';
+      });
+  }
+
+  function reverseGeocode(lat, lon) {
+    return fetch(
+      'https://nominatim.openstreetmap.org/reverse?lat=' +
+        lat +
+        '&lon=' +
+        lon +
+        '&format=json&zoom=10',
+    )
+      .then(function (res) {
+        return res.json();
+      })
+      .then(function (data) {
+        return (
+          data.address.city ||
+          data.address.town ||
+          data.address.village ||
+          data.address.county ||
+          'Unknown'
+        );
+      })
+      .catch(function () {
+        return 'Lat ' + lat.toFixed(1) + ', Lon ' + lon.toFixed(1);
+      });
+  }
+
+  function init() {
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(
+        function (pos) {
+          var lat = pos.coords.latitude;
+          var lon = pos.coords.longitude;
+          reverseGeocode(lat, lon).then(function (city) {
+            fetchWeather(lat, lon, city);
+          });
+        },
+        function () {
+          fetchWeather(DEFAULT_LAT, DEFAULT_LON, DEFAULT_CITY);
+        },
+        { timeout: 5000 },
+      );
+    } else {
+      fetchWeather(DEFAULT_LAT, DEFAULT_LON, DEFAULT_CITY);
+    }
+  }
+
+  init();
+})();

--- a/widget-templates/weather/style.css
+++ b/widget-templates/weather/style.css
@@ -10,7 +10,7 @@
     sans-serif;
   color: white;
   background: linear-gradient(135deg, #1e3a5f, #0f1b2d);
-  padding: 16px 20px;
+  padding: 10px 14px;
   overflow: hidden;
   position: relative;
 }
@@ -19,8 +19,8 @@
   position: absolute;
   top: -30px;
   right: -30px;
-  width: 120px;
-  height: 120px;
+  width: 100px;
+  height: 100px;
   background: radial-gradient(
     circle,
     rgba(251, 191, 36, 0.12),
@@ -31,107 +31,232 @@
 .left {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
   z-index: 1;
 }
 .temp {
-  font-size: 36px;
+  font-size: 28px;
   font-weight: 200;
   line-height: 1;
   letter-spacing: -1px;
 }
 .temp span {
-  font-size: 16px;
+  font-size: 13px;
   font-weight: 400;
   vertical-align: top;
   opacity: 0.5;
   letter-spacing: 0;
 }
 .condition {
-  font-size: 12px;
+  font-size: 10px;
   font-weight: 500;
   opacity: 0.7;
 }
 .location {
-  font-size: 10px;
+  font-size: 8px;
   opacity: 0.35;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
-.center {
-  display: flex;
-  gap: 14px;
-  z-index: 1;
-}
-.detail-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1px;
-}
-.detail-label {
-  font-size: 9px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  opacity: 0.35;
-}
-.detail-value {
-  font-size: 12px;
-  font-weight: 600;
-}
 .icon-wrap {
   position: relative;
-  width: 52px;
-  height: 52px;
+  width: 44px;
+  height: 44px;
   flex-shrink: 0;
   z-index: 1;
 }
 .sun {
-  width: 28px;
-  height: 28px;
+  width: 22px;
+  height: 22px;
   background: #fbbf24;
   border-radius: 50%;
   position: absolute;
   top: 2px;
   right: 2px;
-  box-shadow: 0 0 16px rgba(251, 191, 36, 0.4);
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.4);
   animation: pulse 3s ease-in-out infinite;
+  display: none;
 }
 .cloud {
-  width: 36px;
-  height: 16px;
+  width: 30px;
+  height: 13px;
   background: rgba(255, 255, 255, 0.85);
-  border-radius: 9px;
+  border-radius: 7px;
   position: absolute;
-  bottom: 4px;
+  bottom: 3px;
   left: 0;
+  display: none;
 }
 .cloud::before {
   content: '';
   position: absolute;
-  width: 18px;
-  height: 18px;
+  width: 15px;
+  height: 15px;
   background: rgba(255, 255, 255, 0.85);
   border-radius: 50%;
-  top: -10px;
-  left: 6px;
+  top: -8px;
+  left: 5px;
 }
 .cloud::after {
   content: '';
   position: absolute;
-  width: 12px;
-  height: 12px;
+  width: 10px;
+  height: 10px;
   background: rgba(255, 255, 255, 0.85);
   border-radius: 50%;
-  top: -5px;
-  left: 18px;
+  top: -4px;
+  left: 15px;
 }
+.rain {
+  position: absolute;
+  bottom: 0;
+  left: 8px;
+  display: none;
+}
+.rain-drop {
+  width: 2px;
+  height: 6px;
+  background: rgba(96, 165, 250, 0.7);
+  border-radius: 1px;
+  position: absolute;
+  animation: fall 0.8s linear infinite;
+}
+.rain-drop:nth-child(1) {
+  left: 0;
+  animation-delay: 0s;
+}
+.rain-drop:nth-child(2) {
+  left: 6px;
+  animation-delay: 0.3s;
+}
+.rain-drop:nth-child(3) {
+  left: 12px;
+  animation-delay: 0.15s;
+}
+.snow-dot {
+  width: 3px;
+  height: 3px;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  position: absolute;
+  animation: fall 1.5s linear infinite;
+}
+.snow-dot:nth-child(1) {
+  left: 0;
+  animation-delay: 0s;
+}
+.snow-dot:nth-child(2) {
+  left: 8px;
+  animation-delay: 0.5s;
+}
+.snow-dot:nth-child(3) {
+  left: 16px;
+  animation-delay: 0.25s;
+}
+.snow {
+  position: absolute;
+  bottom: 0;
+  left: 6px;
+  display: none;
+}
+.fog-line {
+  width: 24px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 1px;
+  position: absolute;
+}
+.fog-line:nth-child(1) {
+  top: 0;
+  left: 0;
+}
+.fog-line:nth-child(2) {
+  top: 6px;
+  left: 4px;
+  width: 18px;
+}
+.fog-line:nth-child(3) {
+  top: 12px;
+  left: 2px;
+  width: 20px;
+}
+.fog {
+  position: absolute;
+  top: 10px;
+  left: 8px;
+  display: none;
+}
+.bolt {
+  position: absolute;
+  bottom: 0;
+  left: 14px;
+  width: 8px;
+  height: 14px;
+  display: none;
+}
+.bolt polygon {
+  fill: #fbbf24;
+}
+
+/* weather states */
+.icon-wrap.clear .sun {
+  display: block;
+}
+.icon-wrap.partly-cloudy .sun {
+  display: block;
+}
+.icon-wrap.partly-cloudy .cloud {
+  display: block;
+}
+.icon-wrap.cloudy .cloud {
+  display: block;
+  bottom: 12px;
+  left: 6px;
+}
+.icon-wrap.rain .cloud {
+  display: block;
+}
+.icon-wrap.rain .rain {
+  display: block;
+}
+.icon-wrap.snow .cloud {
+  display: block;
+}
+.icon-wrap.snow .snow {
+  display: block;
+}
+.icon-wrap.fog .fog {
+  display: block;
+}
+.icon-wrap.thunder .cloud {
+  display: block;
+}
+.icon-wrap.thunder .rain {
+  display: block;
+}
+.icon-wrap.thunder .bolt {
+  display: block;
+}
+
 @keyframes pulse {
   0%,
   100% {
-    box-shadow: 0 0 16px rgba(251, 191, 36, 0.4);
+    box-shadow: 0 0 12px rgba(251, 191, 36, 0.4);
   }
   50% {
-    box-shadow: 0 0 24px rgba(251, 191, 36, 0.6);
+    box-shadow: 0 0 20px rgba(251, 191, 36, 0.6);
+  }
+}
+@keyframes fall {
+  0% {
+    transform: translateY(-4px);
+    opacity: 0;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(10px);
+    opacity: 0;
   }
 }

--- a/widget-templates/weather/widget.html
+++ b/widget-templates/weather/widget.html
@@ -1,25 +1,29 @@
 <div class="container">
   <div class="left">
-    <div class="temp">22<span>&deg;C</span></div>
-    <div class="condition">Partly Cloudy</div>
-    <div class="location">San Francisco</div>
+    <div class="temp" id="temp">--<span>&deg;C</span></div>
+    <div class="condition" id="condition">Loading...</div>
+    <div class="location" id="location"></div>
   </div>
-  <div class="center">
-    <div class="detail-item">
-      <span class="detail-label">Wind</span>
-      <span class="detail-value">12 km/h</span>
-    </div>
-    <div class="detail-item">
-      <span class="detail-label">Humidity</span>
-      <span class="detail-value">64%</span>
-    </div>
-    <div class="detail-item">
-      <span class="detail-label">UV</span>
-      <span class="detail-value">3</span>
-    </div>
-  </div>
-  <div class="icon-wrap">
+  <div class="icon-wrap" id="icon-wrap">
     <div class="sun"></div>
     <div class="cloud"></div>
+    <div class="rain">
+      <div class="rain-drop"></div>
+      <div class="rain-drop"></div>
+      <div class="rain-drop"></div>
+    </div>
+    <div class="snow">
+      <div class="snow-dot"></div>
+      <div class="snow-dot"></div>
+      <div class="snow-dot"></div>
+    </div>
+    <div class="fog">
+      <div class="fog-line"></div>
+      <div class="fog-line"></div>
+      <div class="fog-line"></div>
+    </div>
+    <svg class="bolt" viewBox="0 0 8 14">
+      <polygon points="5,0 0,8 4,8 3,14 8,5 4,5" />
+    </svg>
   </div>
 </div>


### PR DESCRIPTION
- Add `Tooltip` component (shadcn) with tooltips on all toolbar icon buttons in main window and widget editor
- Add `widget:reload-all` IPC handler to close, rebuild, and respawn all enabled widgets
- Add `widget:open-widgets-dir` IPC handler to open the widgets directory in Finder; clean up countdown and weather widget templates

Fixes #21