### PR TITLE
Add always-on-top toggle for widgets

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -153,6 +153,7 @@ Widgets automatically hide and become click-through when the cursor approaches a
 Wigify lives in the system tray (menu bar on macOS) for quick access:
 
 - **Auto-hide Widgets**: Toggle cursor dodge on/off (enabled by default)
+- **Always on top**: Toggle whether widgets stay above other app windows
 - **Show Window**: Bring the main Wigify window to the front
 - **Quit**: Exit the application
 

--- a/src/main/menu/tray.ts
+++ b/src/main/menu/tray.ts
@@ -15,6 +15,7 @@ import {
 } from '@/main/system/updater';
 import { isDev } from '@/main/utils/env';
 import { arrangeAllWidgets } from '@/main/widget/grid';
+import { setWidgetsAlwaysOnTop } from '@/main/widget/manager';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const APP_ROOT = path.join(__dirname, '..');
@@ -98,6 +99,15 @@ async function buildContextMenu(): Promise<Menu> {
         }
 
         stopCursorProximityTracking();
+      },
+    },
+    {
+      label: 'Always on top',
+      type: 'checkbox',
+      checked: settings.allwaysOnTop,
+      click: async menuItem => {
+        await updateSetting('allwaysOnTop', menuItem.checked);
+        setWidgetsAlwaysOnTop(menuItem.checked);
       },
     },
     {

--- a/src/main/system/settings.ts
+++ b/src/main/system/settings.ts
@@ -9,12 +9,23 @@ const SETTINGS_FILE = path.join(CONFIG_DIR, 'settings.json');
 
 const DEFAULT_SETTINGS: AppSettings = {
   autoHideWidgets: true,
+  allwaysOnTop: true,
 };
 
 export async function loadSettings(): Promise<AppSettings> {
   try {
     const content = await fs.readFile(SETTINGS_FILE, 'utf-8');
-    const saved = JSON.parse(content) as Partial<AppSettings>;
+    const saved = JSON.parse(content) as Partial<AppSettings> & {
+      pinWidgetsToDesktop?: boolean;
+    };
+
+    if (
+      typeof saved.allwaysOnTop === 'undefined' &&
+      typeof saved.pinWidgetsToDesktop === 'boolean'
+    ) {
+      saved.allwaysOnTop = !saved.pinWidgetsToDesktop;
+    }
+
     return { ...DEFAULT_SETTINGS, ...saved };
   } catch {
     return { ...DEFAULT_SETTINGS };

--- a/src/main/widget/index.ts
+++ b/src/main/widget/index.ts
@@ -48,6 +48,7 @@ export {
   closeAllWidgetWindows,
   updateWidgetWindowPosition,
   updateWidgetWindowSize,
+  setWidgetsAlwaysOnTop,
   setAppQuitting,
 } from '@/main/widget/manager';
 

--- a/src/main/widget/manager.ts
+++ b/src/main/widget/manager.ts
@@ -4,6 +4,7 @@ import type { WidgetInstance, WidgetWindowPayload, WindowData } from '@/types';
 
 import { createWindow, Window } from '@/main/utils/window';
 import { removeWidgetFromTracking } from '@/main/system/cursor-proximity';
+import { loadSettings } from '@/main/system/settings';
 
 import {
   getWidgetInstance,
@@ -48,6 +49,8 @@ export async function spawnWidgetWindow(
     return null;
   }
 
+  const settings = await loadSettings();
+
   const payload: WidgetWindowPayload = {
     instanceId: instance.id,
     widgetName: instance.widgetName,
@@ -83,11 +86,13 @@ export async function spawnWidgetWindow(
     minimizable: false,
     maximizable: false,
     hasShadow: false,
-    focusable: false,
+    focusable: true,
     show: true,
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: -100, y: -100 },
   });
+
+  applyAlwaysOnTop(window.getBrowserWindow(), settings.allwaysOnTop);
 
   widgetPayloads.set(instance.id, windowData);
   window.getBrowserWindow().webContents.send('load', windowData);
@@ -211,6 +216,25 @@ export function closeAllWidgetWindows(): void {
     }
     widgetWindows.delete(instanceId);
     widgetPayloads.delete(instanceId);
+  }
+}
+
+function applyAlwaysOnTop(
+  browserWindow: Electron.BrowserWindow,
+  allwaysOnTop: boolean,
+): void {
+  if (allwaysOnTop) {
+    browserWindow.setAlwaysOnTop(true, 'floating');
+    return;
+  }
+
+  browserWindow.setAlwaysOnTop(true, 'normal', -1);
+}
+
+export function setWidgetsAlwaysOnTop(allwaysOnTop: boolean): void {
+  for (const [, window] of widgetWindows) {
+    if (window.isDestroyed()) continue;
+    applyAlwaysOnTop(window.getBrowserWindow(), allwaysOnTop);
   }
 }
 

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
 export interface AppSettings {
   autoHideWidgets: boolean;
+  allwaysOnTop: boolean;
 }


### PR DESCRIPTION
- Add \"Always on top\" tray menu toggle to control widget window layering
- Persist the setting as `allwaysOnTop` in app settings with migration from legacy `pinWidgetsToDesktop`
- Apply always-on-top state when spawning widgets and when toggling from the tray menu

Closes #20